### PR TITLE
fix typo

### DIFF
--- a/Detector/Communication/Broker.py
+++ b/Detector/Communication/Broker.py
@@ -55,6 +55,6 @@ class BrokerSender:
         signal = ActionRequested(action)
         channel.basic_publish(
             exchange="",
-            routing_key=self.config.gate_action_queue322,
+            routing_key=self.config.gate_action_queue,
             body=signal.to_json(),
         )


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix a typo in the routing key configuration for the SendGateSignal method to ensure the correct queue is used.

Bug Fixes:
- Correct the routing key in the SendGateSignal method to use the correct configuration value.

<!-- Generated by sourcery-ai[bot]: end summary -->